### PR TITLE
Feat/skim - Support multiple finders

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Fuzzback was built using fzf, and only later did I add support for skim. These
 two finders seem mostly comparable, although I might have missed something.
 Please open an issue if you find any problems with this or other.
 
+Additionally the popup window doesn't seem to work in sk-tmux, I'm unable to
+open it on `tmux next-3.4` and `sk 0.10.2`, so it isn't currently configured to
+work.
+
 ### Key binding
 
 The default key-binding is `?` preceded by a prefix, it can be modified by

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Build Status](https://app.travis-ci.com/roosta/tmux-fuzzback.svg?branch=main)](https://app.travis-ci.com/github/roosta/tmux-fuzzback)
 [![GitHub](https://img.shields.io/badge/License-MIT-%232C78BF)](https://github.com/roosta/tmux-fuzzback/blob/master/LICENSE)
 
-tmux-fuzzback uses [fzf](https://github.com/junegunn/fzf) to search terminal
-scrollback buffer, and jump to selected position.
+tmux-fuzzback uses a fuzzy finder to search terminal scrollback buffer, and
+jump to selected position.
 
 ![preview](https://raw.githubusercontent.com/roosta/assets/master/tmux-fuzzback/preview.gif)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ it, and give it some love. I also drew more than a little inspiration from
 ## Requirements
 
 - [tmux](https://github.com/tmux/tmux) version >= [2.4](https://github.com/tmux/tmux/releases/tag/2.4)
-- [fzf](https://github.com/junegunn/fzf)
+- A fuzzy finder
+  - [fzf](https://github.com/junegunn/fzf)
+  - [skim](https://github.com/lotabout/skim) - Requires extra [configuration](#fuzzy-finder)
 
 ## Installation
 
@@ -50,6 +52,18 @@ To use tmux-fuzzback, start it in a tmux session by typing <kbd>prefix</kbd> +
 fzf.
 
 ## Options
+### Fuzzy finder
+
+Fuzzback uses `fzf` as default, but you can set it to `sk` if you'd rather use [skim](https://github.com/lotabout/skim)
+
+```tmux
+set -g @fuzzback-finder 'sk'
+```
+
+Fuzzback was built using fzf, and only later did I add support for skim. These
+two finders seem mostly comparable, although I might have missed something.
+Please open an issue if you find any problems with this or other.
+
 ### Key binding
 
 The default key-binding is `?` preceded by a prefix, it can be modified by
@@ -70,6 +84,8 @@ mind that only recent versions `3.2` and above of tmux support this.
 set -g @fuzzback-popup 1
 ```
 
+***Only works with fzf for the time being***
+
 ### Popup size
 
 You can set the popup size with this option.
@@ -78,26 +94,29 @@ You can set the popup size with this option.
 set -g @fuzzback-popup-size '90%'
 ```
 
-### fzf layout
+### Finder layout
 
-You can reverse the direction of fzf by setting this variable. The default is `default`
+You can reverse the direction of selected finder by setting this variable. The
+default is `default`
 
 ```tmux
-set -g @fuzzback-fzf-layout 'reverse'
+set -g @fuzzback-finder-layout 'reverse'
 ```
 
-### fzf bind
+### Finder bind
 
-If you want to bind some keybinding using fzf --bind that's only used in
+If you want to bind some keybinding using sk/fzf --bind that's only used in
 fuzzback set this variable.
 
 ```tmux
-set -g @fuzzback-fzf-bind 'ctrl-y:execute-silent(echo -n {3..} | xsel -ib)+abort'
+set -g @fuzzback-finder-bind 'ctrl-y:execute-silent(echo -n {3..} | xsel -ib)+abort'
 ```
 
-This will copy the line matches in fzf to the clipboard if `xsel` is available.
+This will copy the line matches in selected finder to the clipboard if `xsel` is available.
 
-Refer to [fzf documentation](https://github.com/junegunn/fzf#executing-external-programs) for more details.
+Refer documentation for more:
+- [fzf documentation](https://github.com/junegunn/fzf#executing-external-programs)
+- [skim documentation](https://github.com/lotabout/skim#keymap)
 
 ### Keybind table
 

--- a/scripts/fuzzback.sh
+++ b/scripts/fuzzback.sh
@@ -28,7 +28,7 @@ finder_split_cmd() {
     --ansi \
     --bind="$1" \
     --delimiter=":" \
-    --layout="$fzf_layout" \
+    --layout="$finder_layout" \
     --no-multi \
     --no-sort \
     --preview-window=nowrap \
@@ -42,7 +42,7 @@ fzf_popup_cmd() {
     --ansi \
     --bind="$2" \
     --delimiter=":" \
-    --layout="$fzf_layout" \
+    --layout="$finder_layout" \
     --no-multi \
     --no-sort \
     --preview-window=nowrap \
@@ -262,7 +262,6 @@ fuzzback() {
   local correct_line_number trimmed_line column pos pos_rev
   local capture_height head_n tail_n
   local enable_popup popup_size finder_bind finder_layout
-  local fzf_layout
 
   create_capture_file
 
@@ -272,7 +271,6 @@ fuzzback() {
   finder_bind="$(tmux_get '@fuzzback-finder-bind' 'ctrl-y:accept')"
   finder_layout="$(tmux_get '@fuzzback-finder-layout' 'default')"
   fuzzback_finder="$(tmux_get '@fuzzback-finder' 'fzf')"
-  fzf_layout="$(tmux_get '@fuzzback-fzf-layout' 'default')"
 
   pos=$(get_pos)
   pane_height="$(tmux display-message -p '#{pane_height}')"

--- a/scripts/fuzzback.sh
+++ b/scripts/fuzzback.sh
@@ -13,16 +13,22 @@ SUPPORTED_VERSION="2.4"
 # shellcheck source=helpers.sh
 . "$CURRENT_DIR/helpers.sh"
 
-fzf_split_cmd() {
-  fzf-tmux -d "70%" \
+finder_split_cmd() {
+  local fuzzback_finder="$3"
+  local finder
+
+  finder='fzf-tmux'
+  if [ "$fuzzback_finder" = "sk" ]; then
+    finder='sk-tmux'
+  fi
+  "$finder" -d "70%" \
     --delimiter=":" \
     --ansi \
     --with-nth="3.." \
     --bind="$1" \
     --no-multi \
     --no-sort \
-    --no-preview \
-    --layout="$fzf_layout" \
+    --layout="$2" \
     --print-query
 
 }
@@ -35,8 +41,7 @@ fzf_popup_cmd() {
     --bind="$2" \
     --no-multi \
     --no-sort \
-    --no-preview \
-    --layout="$fzf_layout" \
+    --layout="$3" \
     --print-query
 }
 
@@ -254,15 +259,16 @@ fuzzback() {
   local match line_number pane_height query max_lines max_jump
   local correct_line_number trimmed_line column pos pos_rev
   local capture_height head_n tail_n
-  local enable_popup popup_size fzf_bind
+  local enable_popup popup_size finder_bind finder_layout
 
   create_capture_file
 
   # Options
   enable_popup="$(tmux_get '@fuzzback-popup' 0)"
   popup_size="$(tmux_get '@fuzzback-popup-size' "50%")"
-  fzf_bind="$(tmux_get '@fuzzback-fzf-bind' 'ctrl-y:accept')"
-  fzf_layout="$(tmux_get '@fuzzback-fzf-layout' 'default')"
+  finder_bind="$(tmux_get '@fuzzback-finder-bind' 'ctrl-y:accept')"
+  finder_layout="$(tmux_get '@fuzzback-finder-layout' 'default')"
+  fuzzback_finder="$(tmux_get '@fuzzback-finder' 'fzf')"
 
   pos=$(get_pos)
   pane_height="$(tmux display-message -p '#{pane_height}')"
@@ -282,9 +288,9 @@ fuzzback() {
 
   # Combine head and tail when searching with fzf
   if [ "$enable_popup" -eq 1 ];then
-    match=$(cat "$tail_file" "$head_file" | fzf_popup_cmd "$popup_size" "$fzf_bind")
+    match=$(cat "$tail_file" "$head_file" | fzf_popup_cmd "$popup_size" "$finder_bind" "$finder_layout")
   else
-    match=$(cat "$tail_file" "$head_file" | fzf_split_cmd "$fzf_bind")
+    match=$(cat "$tail_file" "$head_file" | finder_split_cmd "$finder_bind" "$finder_layout" "$fuzzback_finder")
   fi
 
   if [ "$(echo "$match" | wc -l)" -gt "1" ]; then


### PR DESCRIPTION
## Support multiple finders

Add support for [skim fuzzy finder](https://github.com/lotabout/skim)
Introduces a new variable:
```
set -g @fuzzback-finder 'sk'
```
By default fuzzback will use fzf, but you can tell it to use sk using that var.

### Breaking!

- Variable `fuzzback-fzf-bind` has been renamed to `fuzzback-finder-bind`
- Variable `fuzzback-fzf-layout` has been renamed to `fuzzback-finder-layout`

### Additionally

Preview was introduced in https://github.com/roosta/tmux-fuzzback/pull/11, and was extended to support both finders.

### Issues

Closes #5